### PR TITLE
Increase query size limit from 1K to 4K and remove per field limits

### DIFF
--- a/influx_backend.go
+++ b/influx_backend.go
@@ -218,5 +218,5 @@ func buildFilterSubquery(query *Query) (string, error) {
 var validQueryStringRE = regexp.MustCompile("^[A-Za-z0-9+-_.*:| ]*$")
 
 func isValidFilterString(s string) bool {
-	return len(s) < 128 && validQueryStringRE.MatchString(s)
+	return validQueryStringRE.MatchString(s)
 }

--- a/service.go
+++ b/service.go
@@ -57,7 +57,7 @@ func NewService(config *ServiceConfig) *Service {
 // ServeHTTP parses a query request, translates and forwards it to InfluxDB
 // and writes the results back to the client.
 func (svc *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	r.Body = http.MaxBytesReader(w, r.Body, 1024)
+	r.Body = http.MaxBytesReader(w, r.Body, 4096)
 
 	requestStartTime := time.Now()
 

--- a/service_test.go
+++ b/service_test.go
@@ -155,7 +155,7 @@ func TestRequestSizeLimit(t *testing.T) {
 		"filter": {
 			"uhoh": "%s"
 		}
-	}`, strings.Repeat("x", 1024)))
+	}`, strings.Repeat("x", 4096)))
 
 	r := httptest.NewRequest("POST", "/", body)
 	w := httptest.NewRecorder()


### PR DESCRIPTION
This PR increases the query body size limit from 1K to 4K. We are removing the per field limit since the entire body is covered by the 4K limit now.