### PR TITLE
Use InfluxDB's build-in query request queue

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,8 +13,6 @@ import (
 
 func main() {
 	addr := flag.String("addr", ":10000", "service addr")
-	requestQueueSize := flag.Int("request-queue-size", 10, "service request queue size")
-	requestQueueTimeout := flag.Duration("request-queue-timeout", 10*time.Second, "service request queue timeout duration")
 	influxdbURL := flag.String("influxdb.url", getenv("INFLUXDB_URL", "http://localhost:8086"), "influxdb url")
 	influxdbToken := flag.String("influxdb.token", getenv("INFLUXDB_TOKEN", ""), "influxdb token")
 	influxdbBucket := flag.String("influxdb.bucket", getenv("INFLUXDB_BUCKET", ""), "influxdb bucket")
@@ -36,8 +34,6 @@ func main() {
 			Org:    "waggle",
 			Bucket: *influxdbBucket,
 		},
-		RequestQueueSize:    requestQueueSize,
-		RequestQueueTimeout: requestQueueTimeout,
 	})
 
 	streamSvc := &StreamService{
@@ -52,7 +48,6 @@ func main() {
 	http.Handle("/api/v0/stream", streamSvc)
 
 	log.Printf("service listening on %s", *addr)
-	log.Printf("request queue size is %d with %s timeout", *requestQueueSize, *requestQueueTimeout)
 	if err := http.ListenAndServe(*addr, nil); err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This PR drops the data API maintaining its own query request queue and instead uses InfluxDB.

Background notes: At one point, I don't remember InfluxDB's query queue being configurable, hence adding our own. This may have been an oversight at the time. We will now just use the built-in one to simplify this service.